### PR TITLE
Control in onActivityResult for events generated in others plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,70 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# Visual Studio Code related
+.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.flutter-plugins
+.packages
+.pub-cache/
+.pub/
+/build/
+
+# Android related
+**/android/**/gradle-wrapper.jar
+**/android/.gradle
+**/android/captures/
+**/android/gradlew
+**/android/gradlew.bat
+**/android/local.properties
+**/android/**/GeneratedPluginRegistrant.java
+
+# iOS/XCode related
+**/ios/**/*.mode1v3
+**/ios/**/*.mode2v3
+**/ios/**/*.moved-aside
+**/ios/**/*.pbxuser
+**/ios/**/*.perspectivev3
+**/ios/**/*sync/
+**/ios/**/.sconsign.dblite
+**/ios/**/.tags*
+**/ios/**/.vagrant/
+**/ios/**/DerivedData/
+**/ios/**/Icon?
+**/ios/**/Pods/
+**/ios/**/.symlinks/
+**/ios/**/profile
+**/ios/**/xcuserdata
+**/ios/.generated/
+**/ios/Flutter/App.framework
+**/ios/Flutter/Flutter.framework
+**/ios/Flutter/Generated.xcconfig
+**/ios/Flutter/app.flx
+**/ios/Flutter/app.zip
+**/ios/Flutter/flutter_assets/
+**/ios/ServiceDefinitions.json
+**/ios/Runner/GeneratedPluginRegistrant.*
+
+# Exceptions to above rules.
+!**/ios/**/default.mode1v3
+!**/ios/**/default.mode2v3
+!**/ios/**/default.pbxuser
+!**/ios/**/default.perspectivev3
+!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages

--- a/flutter-hms-iap/android/src/main/java/com/huawei/hms/flutter/iap/MethodCallHandlerImpl.java
+++ b/flutter-hms-iap/android/src/main/java/com/huawei/hms/flutter/iap/MethodCallHandlerImpl.java
@@ -231,6 +231,9 @@ public class MethodCallHandlerImpl implements MethodCallHandler, ActivityResultL
 
     @Override
     public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
+        if( !mResultsForRequests.containsKey(requestCode) && !mResultsForRequests.containsKey(requestCode)){
+            return  true;
+        }
         final Result result = Objects.requireNonNull(mResultsForRequests.get(requestCode)).first;
         final int requestType = Objects.requireNonNull(mResultsForRequests.get(requestCode)).second;
 

--- a/flutter-hms-iap/pubspec.yaml
+++ b/flutter-hms-iap/pubspec.yaml
@@ -1,6 +1,6 @@
 name: huawei_iap
 description: HUAWEI IAP Kit plugin for Flutter.  Huawei's In-App Purchases (IAP) service allows you to offer in-app purchases and facilitates in-app payment.
-version: 5.0.0+300
+version: 5.0.1+301
 homepage: https://www.huawei.com
 repository: https://github.com/HMS-Core/hms-flutter-plugin/tree/master/flutter-hms-iap
 


### PR DESCRIPTION
I have added a control in onActivityResult for events generated in others  plugins like google_sign_in, as this throws a NullPointerException if the requestCode is not found in mResultsForRequest