### PR TITLE
Fix run hms-map example.

### DIFF
--- a/flutter-hms-map/example/android/app/src/main/AndroidManifest.xml
+++ b/flutter-hms-map/example/android/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+    <uses-permission android:name="com.huawei.appmarket.service.commondata.permission.GET_COMMON_DATA"/>
 
     <application
         android:name="io.flutter.app.FlutterApplication"


### PR DESCRIPTION
Hi,

I couldn't run the sample under `flutter-hms-map/example/` 

Added a new `uses-permission` in `AndroidManifest.xml` and I was able to run it :)

`<uses-permission android:name="com.huawei.appmarket.service.commondata.permission.GET_COMMON_DATA"/>`

